### PR TITLE
feat: add code samples for Testing Pulumi stacks locally with MiniStack

### DIFF
--- a/testing-pulumi-ministack/.github/workflows/infrastructure-tests.yml
+++ b/testing-pulumi-ministack/.github/workflows/infrastructure-tests.yml
@@ -1,0 +1,72 @@
+name: Infrastructure Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      ministack:
+        image: ministackorg/ministack:latest
+        ports:
+          - 4566:4566
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_ministack/health || exit 1"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localhost:4566
+      PULUMI_CONFIG_PASSPHRASE: test-passphrase
+      PULUMI_BACKEND_URL: file://./.pulumi-state
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - run: npm ci
+
+      - name: Pulumi Preview
+        uses: pulumi/actions@v6
+        with:
+          command: preview
+          stack-name: local
+          work-dir: .
+          upsert: true
+
+      - name: Pulumi Up
+        uses: pulumi/actions@v6
+        with:
+          command: up
+          stack-name: local
+          work-dir: .
+
+      - name: Verify resources
+        run: |
+          echo "Checking DynamoDB table..."
+          aws --endpoint-url=http://localhost:4566 \
+            dynamodb describe-table \
+            --table-name users \
+            --query 'Table.TableName' --output text
+
+          echo "Checking secret..."
+          aws --endpoint-url=http://localhost:4566 \
+            secretsmanager describe-secret \
+            --secret-id db-password \
+            --query 'Name' --output text
+
+      - name: Destroy
+        if: always
+        uses: pulumi/actions@v6
+        with:
+          command: destroy
+          stack-name: local
+          work-dir: .

--- a/testing-pulumi-ministack/.gitignore
+++ b/testing-pulumi-ministack/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+bin/
+.pulumi-state/
+Pulumi.*.yaml
+!Pulumi.yaml
+!Pulumi.local.yaml

--- a/testing-pulumi-ministack/Makefile
+++ b/testing-pulumi-ministack/Makefile
@@ -1,0 +1,23 @@
+MINISTACK_ENV  = AWS_ENDPOINT_URL=http://localhost:4566 \
+                 AWS_ACCESS_KEY_ID=test \
+                 AWS_SECRET_ACCESS_KEY=test \
+                 AWS_DEFAULT_REGION=us-east-1 \
+                 PULUMI_CONFIG_PASSPHRASE=test-passphrase \
+                 PULUMI_BACKEND_URL=file://./.pulumi-state
+
+.PHONY: init local-preview local-up local-destroy reset
+
+init:
+	$(MINISTACK_ENV) pulumi stack select local --create
+
+local-preview:
+	$(MINISTACK_ENV) pulumi preview
+
+local-up:
+	$(MINISTACK_ENV) pulumi up
+
+local-destroy:
+	$(MINISTACK_ENV) pulumi destroy
+
+reset:
+	curl -X POST http://localhost:4566/_ministack/reset

--- a/testing-pulumi-ministack/Pulumi.local.yaml
+++ b/testing-pulumi-ministack/Pulumi.local.yaml
@@ -1,0 +1,22 @@
+config:
+  aws:region: us-east-1
+  aws:accessKey: test
+  aws:secretKey: test
+  aws:s3UsePathStyle: true
+  aws:skipCredentialsValidation: true
+  aws:skipMetadataApiCheck: true
+  aws:skipRequestingAccountId: true
+  aws:endpoints:
+    - s3: http://localhost:4566
+      dynamodb: http://localhost:4566
+      secretsmanager: http://localhost:4566
+      sqs: http://localhost:4566
+      sns: http://localhost:4566
+      lambda: http://localhost:4566
+      iam: http://localhost:4566
+      sts: http://localhost:4566
+      cloudformation: http://localhost:4566
+      route53: http://localhost:4566
+      cloudwatch: http://localhost:4566
+      ssm: http://localhost:4566
+      kms: http://localhost:4566

--- a/testing-pulumi-ministack/Pulumi.yaml
+++ b/testing-pulumi-ministack/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ministack-pulumi-demo
+description: A Pulumi stack testable locally with MiniStack
+runtime: nodejs

--- a/testing-pulumi-ministack/README.md
+++ b/testing-pulumi-ministack/README.md
@@ -1,0 +1,66 @@
+# Testing Pulumi locally with MiniStack
+
+Sample codebase accompanying the blog post [Testing Pulumi stacks locally with MiniStack](https://ahanoff.dev/blog/testing-pulumi-locally-with-ministack).
+
+## Prerequisites
+
+- [Podman](https://podman.io/getting-started/installation) (or [Docker](https://docs.docker.com/get-docker/))
+- [Pulumi CLI](https://www.pulumi.com/docs/install/)
+- Node.js 24
+
+## Quick start
+
+Start MiniStack:
+
+```bash
+podman run -p 4566:4566 ministackorg/ministack
+
+# Docker works too
+# docker run -p 4566:4566 ministackorg/ministack
+```
+
+Install dependencies and run the stack:
+
+```bash
+npm install
+make init           # create the local stack (once)
+make local-preview   # dry run
+make local-up        # deploy against MiniStack
+```
+
+Verify resources exist in MiniStack:
+
+```bash
+aws --endpoint-url=http://localhost:4566 \
+  dynamodb describe-table --table-name users \
+  --query 'Table.TableName' --output text
+
+aws --endpoint-url=http://localhost:4566 \
+  secretsmanager describe-secret --secret-id db-password \
+  --query 'Name' --output text
+```
+
+Clean up:
+
+```bash
+make local-destroy
+make reset
+```
+
+## What's in here
+
+| File | Purpose |
+| --- | --- |
+| `Pulumi.yaml` | Project definition |
+| `Pulumi.local.yaml` | Stack config with MiniStack endpoint overrides |
+| `index.ts` | Infrastructure: native DynamoDB table + custom dynamic resource |
+| `managed-secret.ts` | Custom `pulumi.dynamic.ResourceProvider` for Secrets Manager |
+| `Makefile` | Convenience commands for local testing |
+| `.github/workflows/infrastructure-tests.yml` | GitHub Actions CI workflow |
+
+## The two layers
+
+1. **`Pulumi.local.yaml`**: endpoint overrides for the native `@pulumi/aws` provider.
+2. **`AWS_ENDPOINT_URL`**: endpoint override for the AWS SDK used by custom resources.
+
+Both must point at MiniStack. The `Makefile` and CI workflow set both.

--- a/testing-pulumi-ministack/index.ts
+++ b/testing-pulumi-ministack/index.ts
@@ -1,0 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { ManagedSecret } from "./managed-secret";
+
+// Native resource: the AWS provider handles it via Pulumi.local.yaml endpoints.
+const table = new aws.dynamodb.Table("users", {
+    name: "users",
+    billingMode: "PAY_PER_REQUEST",
+    hashKey: "userId",
+    attributes: [{ name: "userId", type: "S" }],
+});
+
+// Custom dynamic resource: uses the AWS SDK directly via AWS_ENDPOINT_URL.
+const dbPassword = new ManagedSecret("db-password", {
+    name: "db-password",
+    length: 32,
+    excludePunctuation: true,
+});
+
+export const tableName = table.name;
+export const secretArn = dbPassword.arn;

--- a/testing-pulumi-ministack/managed-secret.ts
+++ b/testing-pulumi-ministack/managed-secret.ts
@@ -1,0 +1,201 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as crypto from "crypto";
+import {
+    SecretsManagerClient,
+    CreateSecretCommand,
+    PutSecretValueCommand,
+    DeleteSecretCommand,
+    DescribeSecretCommand,
+} from "@aws-sdk/client-secrets-manager";
+
+// --- Password generation ---
+
+interface PasswordPolicy {
+    length: number;
+    excludeUppercase?: boolean;
+    excludeLowercase?: boolean;
+    excludeNumbers?: boolean;
+    excludePunctuation?: boolean;
+}
+
+function generatePassword(policy: PasswordPolicy): string {
+    let charset = "";
+    if (!policy.excludeLowercase) charset += "abcdefghijklmnopqrstuvwxyz";
+    if (!policy.excludeUppercase) charset += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    if (!policy.excludeNumbers) charset += "0123456789";
+    if (!policy.excludePunctuation) charset += "!@#$%^&*()-_=+[]{}|;:,.<>?";
+
+    if (charset.length === 0) {
+        throw new Error("Password policy excludes all character sets");
+    }
+
+    const bytes = crypto.randomBytes(policy.length);
+    return Array.from(bytes, (b) => charset[b % charset.length]).join("");
+}
+
+// --- Types ---
+
+interface ManagedSecretInputs extends PasswordPolicy {
+    name: string;
+}
+
+// --- Provider ---
+
+function getClient(): SecretsManagerClient {
+    // AWS SDK v3.362.0+ reads AWS_ENDPOINT_URL automatically.
+    // Passing it explicitly also works and supports older SDK versions.
+    return new SecretsManagerClient({
+        endpoint: process.env.AWS_ENDPOINT_URL,
+    });
+}
+
+class ManagedSecretProvider implements pulumi.dynamic.ResourceProvider {
+    async create(inputs: pulumi.Inputs): Promise<pulumi.dynamic.CreateResult> {
+        const props = inputs as unknown as ManagedSecretInputs;
+        const password = generatePassword(props);
+
+        const client = getClient();
+        const result = await client.send(
+            new CreateSecretCommand({
+                Name: props.name,
+                SecretString: password,
+            }),
+        );
+
+        return {
+            id: result.ARN!,
+            outs: {
+                ...props,
+                arn: result.ARN!,
+                versionId: result.VersionId!,
+                generatedPassword: password,
+            },
+        };
+    }
+
+    async diff(
+        id: string,
+        olds: pulumi.Inputs,
+        news: pulumi.Inputs,
+    ): Promise<pulumi.dynamic.DiffResult> {
+        const o = olds as unknown as ManagedSecretInputs;
+        const n = news as unknown as ManagedSecretInputs;
+
+        const replaces: string[] = [];
+
+        // Secret name is immutable in AWS; changing it forces replacement.
+        if (o.name !== n.name) {
+            replaces.push("name");
+        }
+
+        // Password policy changes are handled by update (rotation).
+        const policyChanged =
+            o.length !== n.length ||
+            o.excludeUppercase !== n.excludeUppercase ||
+            o.excludeLowercase !== n.excludeLowercase ||
+            o.excludeNumbers !== n.excludeNumbers ||
+            o.excludePunctuation !== n.excludePunctuation;
+
+        return {
+            changes: replaces.length > 0 || policyChanged,
+            replaces,
+        };
+    }
+
+    async update(
+        id: string,
+        _olds: pulumi.Inputs,
+        news: pulumi.Inputs,
+    ): Promise<pulumi.dynamic.UpdateResult> {
+        const props = news as unknown as ManagedSecretInputs;
+        const password = generatePassword(props);
+
+        const client = getClient();
+        const result = await client.send(
+            new PutSecretValueCommand({
+                SecretId: id,
+                SecretString: password,
+            }),
+        );
+
+        return {
+            outs: {
+                ...props,
+                arn: id,
+                versionId: result.VersionId!,
+                generatedPassword: password,
+            },
+        };
+    }
+
+    async delete(id: string, _props: pulumi.Inputs): Promise<void> {
+        const client = getClient();
+        try {
+            await client.send(
+                new DeleteSecretCommand({
+                    SecretId: id,
+                    ForceDeleteWithoutRecovery: true,
+                }),
+            );
+        } catch (e: unknown) {
+            // Idempotent: ignore if already deleted.
+            if (e instanceof Error && e.name !== "ResourceNotFoundException") {
+                throw e;
+            }
+        }
+    }
+
+    async read(id: string, props: pulumi.Inputs): Promise<pulumi.dynamic.ReadResult> {
+        const client = getClient();
+        const result = await client.send(
+            new DescribeSecretCommand({ SecretId: id }),
+        );
+
+        return {
+            id: result.ARN ?? id,
+            props: { ...props, arn: result.ARN ?? id },
+        };
+    }
+}
+
+// --- Resource ---
+
+export interface ManagedSecretArgs {
+    name: pulumi.Input<string>;
+    length?: pulumi.Input<number>;
+    excludeUppercase?: pulumi.Input<boolean>;
+    excludeLowercase?: pulumi.Input<boolean>;
+    excludeNumbers?: pulumi.Input<boolean>;
+    excludePunctuation?: pulumi.Input<boolean>;
+}
+
+export class ManagedSecret extends pulumi.dynamic.Resource {
+    public readonly arn!: pulumi.Output<string>;
+    public readonly versionId!: pulumi.Output<string>;
+    public readonly generatedPassword!: pulumi.Output<string>;
+
+    constructor(name: string, args: ManagedSecretArgs, opts?: pulumi.CustomResourceOptions) {
+        const provider = new ManagedSecretProvider();
+        super(
+            provider,
+            name,
+            {
+                // Output-only properties, populated by the provider's outs
+                arn: undefined,
+                versionId: undefined,
+                generatedPassword: undefined,
+                // Input properties with defaults
+                length: 32,
+                excludeUppercase: false,
+                excludeLowercase: false,
+                excludeNumbers: false,
+                excludePunctuation: false,
+                ...args,
+            },
+            {
+                additionalSecretOutputs: ["generatedPassword"],
+                ...opts,
+            },
+        );
+    }
+}

--- a/testing-pulumi-ministack/package.json
+++ b/testing-pulumi-ministack/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ministack-pulumi-demo",
+  "version": "0.1.0",
+  "description": "Testing Pulumi infrastructure locally with MiniStack",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^7.0.0",
+    "@pulumi/pulumi": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/testing-pulumi-ministack/tsconfig.json
+++ b/testing-pulumi-ministack/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Sample codebase for the blog post [Testing Pulumi stacks locally with MiniStack](https://ahanoff.dev/blog/testing-pulumi-locally-with-ministack).

Includes:
- Native DynamoDB table + custom dynamic resource (ManagedSecret)
- `Pulumi.local.yaml` with MiniStack endpoint overrides
- Per-project state isolation via `PULUMI_BACKEND_URL=file://./.pulumi-state`
- Makefile with convenience commands
- GitHub Actions CI workflow (checkout@v6, setup-node@v6, pulumi/actions@v6)