### PR TITLE
feat: add pre-push hook for MiniStack preview validation

### DIFF
--- a/testing-pulumi-ministack/.githooks/pre-push
+++ b/testing-pulumi-ministack/.githooks/pre-push
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-push hook: runs pulumi preview against MiniStack if it is running.
+# Blocks the push if preview finds unsupported resources or errors.
+# If MiniStack is not running, skips with a warning.
+
+set -euo pipefail
+
+MINISTACK_URL="http://localhost:4566"
+
+# Skip if MiniStack is not running
+if ! curl -sf "${MINISTACK_URL}/_ministack/health" >/dev/null 2>&1; then
+    echo "⏭  MiniStack not running, skipping preview check."
+    echo "   Start it: podman run -p 4566:4566 ministackorg/ministack"
+    exit 0
+fi
+
+echo "▶ Running pulumi preview against MiniStack..."
+
+AWS_ENDPOINT_URL="${MINISTACK_URL}" \
+AWS_ACCESS_KEY_ID=test \
+AWS_SECRET_ACCESS_KEY=test \
+AWS_DEFAULT_REGION=us-east-1 \
+PULUMI_CONFIG_PASSPHRASE=test-passphrase \
+PULUMI_BACKEND_URL=file://./.pulumi-state \
+pulumi preview --diff 2>&1
+
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo ""
+    echo "✗ pulumi preview failed. Push blocked."
+    echo "  A resource may not be supported by MiniStack."
+    echo "  Check coverage: https://ministack.org/docs/services/"
+    exit 1
+fi
+
+echo ""
+echo "✓ pulumi preview passed."

--- a/testing-pulumi-ministack/README.md
+++ b/testing-pulumi-ministack/README.md
@@ -56,7 +56,18 @@ make reset
 | `index.ts` | Infrastructure: native DynamoDB table + custom dynamic resource |
 | `managed-secret.ts` | Custom `pulumi.dynamic.ResourceProvider` for Secrets Manager |
 | `Makefile` | Convenience commands for local testing |
+| `.githooks/pre-push` | Blocks push if `pulumi preview` fails against MiniStack |
 | `.github/workflows/infrastructure-tests.yml` | GitHub Actions CI workflow |
+
+## Pre-push hook
+
+A git hook in `.githooks/pre-push` runs `pulumi preview` against MiniStack before every push. If MiniStack is not running, it skips with a warning. If preview fails (unsupported resource, config error), the push is blocked.
+
+Enable it once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
 
 ## The two layers
 


### PR DESCRIPTION
A pre-push git hook that runs pulumi preview against MiniStack before allowing a push. If MiniStack is not running, it skips with a warning. If preview fails (unsupported resource, config error), the push is blocked.

Enable: `git config core.hooksPath .githooks`